### PR TITLE
Replace Intro page with Home as default route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import "./App.css";
 import { lazy } from "react";
 
 const Layout = lazy(() => import("./pages/Layout/Layout"));
-const Intro = lazy(() => import("./pages/Intro/Intro"));
 const Home = lazy(() => import("./pages/Home/Home"));
 const Search = lazy(() => import("./pages/Search/Search"));
 const PlaylistPage = lazy(() => import("./pages/Playlist/PlaylistPage"));
@@ -27,7 +26,7 @@ export default function App() {
   const router = createBrowserRouter(
     createRoutesFromElements(
       <Route path="/" element={<Layout />}>
-        <Route index element={<Intro />} />
+        <Route index element={<Home />} />
         <Route path="/*" element={<NotFound />} />
         <Route path="/home" element={<Home />} />
         <Route path="/search" element={<Search />} />

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,7 +1,7 @@
 import { memo, Suspense, useEffect, useRef } from "react";
 import { useBoundStore } from "../../store/store";
 import { useNavigate } from "react-router-dom";
-import { Image, TrackDetails } from "../../types/GlobalTypes";
+import { TrackDetails } from "../../types/GlobalTypes";
 import Section from "../../components/Section/Section";
 import play from "../../assets/svgs/play-icon.svg";
 import pause from "../../assets/svgs/pause-icon.svg";
@@ -95,8 +95,7 @@ const Widget = memo(
       gcTime: 1000 * 60 * 10,
     });
     const lcpImg =
-      data?.image.find((img: Image) => img.quality === "500x500")?.url ??
-      widgetfallback;
+      "https://cdn.builder.io/api/v1/image/assets%2F7fdba7c800c44f0cb37f2fe3a470643e%2F8b66ba9564f54d2a92f8a5daccf3ef4a";
 
     const handlePlaylist = (
       e: React.MouseEvent<HTMLButtonElement, MouseEvent>,


### PR DESCRIPTION
## Purpose
Based on the conversation history, the user wanted to make visual changes to the Home page component, specifically updating the routing structure to use Home as the default landing page instead of the Intro page.

## Code changes
- **Routing updates**: Removed the Intro page import and changed the index route from `<Intro />` to `<Home />` in App.tsx
- **Home component cleanup**: Removed unused `Image` type import and replaced dynamic image URL logic with a hardcoded CDN URL for the LCP (Largest Contentful Paint) image
- **Simplified image handling**: Replaced the image quality filtering logic with a direct CDN URL reference

These changes streamline the routing structure and optimize the Home page's image loading performance.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a58a5006654144dd8850f5fd531bda15/curry-verse)

👀 [Preview Link](https://a58a5006654144dd8850f5fd531bda15-curry-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a58a5006654144dd8850f5fd531bda15</projectId>-->
<!--<branchName>curry-verse</branchName>-->